### PR TITLE
Variable ToString includes datatype in output.

### DIFF
--- a/SharpSnmpLib/Variable.cs
+++ b/SharpSnmpLib/Variable.cs
@@ -159,7 +159,7 @@ namespace Lextm.SharpSnmpLib
         /// <returns></returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.InvariantCulture, "Variable: Id: {0}; Data: {1}", Id, Data);
+            return string.Format(CultureInfo.InvariantCulture, "Variable: Id: {0}; {1}: {2}", Id, Data.TypeCode.ToString(), Data);
         }
     }
 }

--- a/Tests/CSharpCore/Tests.NetStandard.csproj
+++ b/Tests/CSharpCore/Tests.NetStandard.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutputType Condition="'$(TargetFramework)'!='net452'">Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.0;net452</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />

--- a/Tests/CSharpCore/Unit/VariableTestFixture.cs
+++ b/Tests/CSharpCore/Unit/VariableTestFixture.cs
@@ -38,7 +38,7 @@ namespace Lextm.SharpSnmpLib.Unit
         public void TestToString()
         {
             var v = new Variable(new uint[] {1, 3, 6});
-            Assert.Equal("Variable: Id: 1.3.6; Data: Null", v.ToString());
+            Assert.Equal("Variable: Id: 1.3.6; Null: Null", v.ToString());
         }
         
         [Fact]


### PR DESCRIPTION
Added SNMP Data type to Variable ToString method.  This is helpful when performing a MIB Walk, etc so the data type is obvious.