### PR TITLE
added engineId optional parameter to EngineGroup constructor.

### DIFF
--- a/SharpSnmpLib/Pipeline/EngineGroup.cs
+++ b/SharpSnmpLib/Pipeline/EngineGroup.cs
@@ -27,8 +27,7 @@ namespace Lextm.SharpSnmpLib.Pipeline
     /// </summary>
     public sealed class EngineGroup
     {
-        private readonly OctetString _engineId =
-            new OctetString(new byte[] { 128, 0, 31, 136, 128, 233, 99, 0, 0, 214, 31, 244 });
+        private readonly OctetString _engineId;
         
         private readonly DateTime _start;
         private uint _counterNotInTimeWindow;
@@ -44,7 +43,11 @@ namespace Lextm.SharpSnmpLib.Pipeline
         public EngineGroup(byte[] engineId = null)
         {
             _start = DateTime.UtcNow;
-            if (engineId != null) { _engineId = new OctetString(engineId); }
+            if(engineId == null) {
+                _engineId = new OctetString(new byte[] { 128, 0, 31, 136, 128, 233, 99, 0, 0, 214, 31, 244 });
+            } else {
+                _engineId = engineId;
+            }            
         }
         
         /// <summary>

--- a/SharpSnmpLib/Pipeline/EngineGroup.cs
+++ b/SharpSnmpLib/Pipeline/EngineGroup.cs
@@ -42,9 +42,10 @@ namespace Lextm.SharpSnmpLib.Pipeline
         /// <summary>
         /// Initializes a new instance of the <see cref="EngineGroup"/> class.
         /// </summary>
-        public EngineGroup()
+        public EngineGroup(byte[] engineId = null)
         {
             _start = DateTime.UtcNow;
+            if (engineId != null) { _engineId = new OctetString(engineId); }
         }
         
         /// <summary>

--- a/SharpSnmpLib/Pipeline/EngineGroup.cs
+++ b/SharpSnmpLib/Pipeline/EngineGroup.cs
@@ -27,7 +27,6 @@ namespace Lextm.SharpSnmpLib.Pipeline
     /// </summary>
     public sealed class EngineGroup
     {
-        // TODO: make engine ID configurable from outside and unique.
         private readonly OctetString _engineId =
             new OctetString(new byte[] { 128, 0, 31, 136, 128, 233, 99, 0, 0, 214, 31, 244 });
         


### PR DESCRIPTION
The EngineId has to be unique for each application/agent per network. Thus, EngineGroup has to be configurable in this aspect. This commit proposes an optional parameter to the EngineGroup constructor, and sets the EngineId to the provided byte array if not null.