### PR TITLE
Cancellation token

### DIFF
--- a/SharpSnmpLib/Messaging/Discovery.cs
+++ b/SharpSnmpLib/Messaging/Discovery.cs
@@ -30,6 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
+using System.Threading;
 using Lextm.SharpSnmpLib.Security;
 using System.Threading.Tasks;
 
@@ -203,8 +204,9 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// Gets the response.
         /// </summary>
         /// <param name="receiver">The receiver.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns></returns>
-        public async Task<ReportMessage> GetResponseAsync(IPEndPoint receiver)
+        public async Task<ReportMessage> GetResponseAsync(IPEndPoint receiver, CancellationToken cancellationToken = default)
         {
             if (receiver == null)
             {
@@ -213,7 +215,7 @@ namespace Lextm.SharpSnmpLib.Messaging
 
             using (var socket = receiver.GetSocket())
             {
-                return (ReportMessage)await _discovery.GetResponseAsync(receiver, Empty, socket).ConfigureAwait(false);
+                return (ReportMessage)await _discovery.GetResponseAsync(receiver, Empty, socket, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/SharpSnmpLib/Messaging/Messenger.cs
+++ b/SharpSnmpLib/Messaging/Messenger.cs
@@ -271,8 +271,8 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <returns>Returns row count if the OID is a table. Otherwise this value is meaningless.</returns>
         /// <remarks>This method only supports SNMP v2c and v3.</remarks>
         [Obsolete("Please use other overloading ones.")]
-        public static async Task<int> BulkWalkAsync(VersionCode version, IPEndPoint endpoint, OctetString community, ObjectIdentifier table, IList<Variable> list, int maxRepetitions, WalkMode mode, IPrivacyProvider privacy, ISnmpMessage report, CancellationToken cancellationToken = default)
-            => await BulkWalkAsync(version, endpoint, community, OctetString.Empty, table, list, maxRepetitions, mode, privacy, report, cancellationToken);
+        public static Task<int> BulkWalkAsync(VersionCode version, IPEndPoint endpoint, OctetString community, ObjectIdentifier table, IList<Variable> list, int maxRepetitions, WalkMode mode, IPrivacyProvider privacy, ISnmpMessage report, CancellationToken cancellationToken = default)
+            => BulkWalkAsync(version, endpoint, community, OctetString.Empty, table, list, maxRepetitions, mode, privacy, report, cancellationToken);
 
         /// <summary>
         /// Walks (based on GET BULK).
@@ -399,8 +399,8 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <remarks>This method supports SNMP v2c and v3.</remarks>
         [CLSCompliant(false)]
         [Obsolete("Please use other overloading ones.")]
-        public static async Task SendInformAsync(int requestId, VersionCode version, IPEndPoint receiver, OctetString community, ObjectIdentifier enterprise, uint timestamp, IList<Variable> variables, IPrivacyProvider privacy, ISnmpMessage report, CancellationToken cancellationToken = default)
-            => await SendInformAsync(requestId, version, receiver, community, OctetString.Empty,  enterprise, timestamp, variables, privacy, report, cancellationToken);
+        public static Task SendInformAsync(int requestId, VersionCode version, IPEndPoint receiver, OctetString community, ObjectIdentifier enterprise, uint timestamp, IList<Variable> variables, IPrivacyProvider privacy, ISnmpMessage report, CancellationToken cancellationToken = default)
+            => SendInformAsync(requestId, version, receiver, community, OctetString.Empty,  enterprise, timestamp, variables, privacy, report, cancellationToken);
 
         /// <summary>
         /// Sends INFORM message.
@@ -507,8 +507,8 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// </returns>
         /// <remarks>This method supports SNMP v2c and v3.</remarks>
         [Obsolete("Please use other overloading ones.")]
-        private static async Task<Tuple<bool, IList<Variable>, ISnmpMessage>> BulkHasNextAsync(VersionCode version, IPEndPoint receiver, OctetString community, Variable seed, int maxRepetitions, IPrivacyProvider privacy, ISnmpMessage report, CancellationToken cancellationToken = default)
-            => await BulkHasNextAsync(version, receiver, community, OctetString.Empty, seed, maxRepetitions, privacy, report, cancellationToken);
+        private static Task<Tuple<bool, IList<Variable>, ISnmpMessage>> BulkHasNextAsync(VersionCode version, IPEndPoint receiver, OctetString community, Variable seed, int maxRepetitions, IPrivacyProvider privacy, ISnmpMessage report, CancellationToken cancellationToken = default)
+            => BulkHasNextAsync(version, receiver, community, OctetString.Empty, seed, maxRepetitions, privacy, report, cancellationToken);
 
         /// <summary>
         /// Determines whether the specified seed has next item.

--- a/SharpSnmpLib/Messaging/SnmpMessageExtension.cs
+++ b/SharpSnmpLib/Messaging/SnmpMessageExtension.cs
@@ -422,7 +422,7 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="manager">Manager</param>
         /// <param name="socket">The socket.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
-        public static async Task SendAsync(this ISnmpMessage message, EndPoint manager, Socket socket, CancellationToken cancellationToken = default)
+        public static Task SendAsync(this ISnmpMessage message, EndPoint manager, Socket socket, CancellationToken cancellationToken = default)
         {
             if (message == null)
             {
@@ -449,7 +449,7 @@ namespace Lextm.SharpSnmpLib.Messaging
             }
 
             var buffer = new ArraySegment<byte>(message.ToBytes());
-            await socket.SendToAsync(buffer, SocketFlags.None, manager, cancellationToken);
+            return socket.SendToAsync(buffer, SocketFlags.None, manager, cancellationToken);
         }
 
         /// <summary>
@@ -524,7 +524,7 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="udpSocket">The UDP <see cref="Socket"/> to use to send/receive.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns></returns>
-        public static async Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, Socket udpSocket, CancellationToken cancellationToken = default)
+        public static Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, Socket udpSocket, CancellationToken cancellationToken = default)
         {
             if (request == null)
             {
@@ -547,7 +547,7 @@ namespace Lextm.SharpSnmpLib.Messaging
                 registry.Add(request.Parameters.UserName, request.Privacy);
             }
 
-            return await request.GetResponseAsync(receiver, registry, udpSocket, cancellationToken).ConfigureAwait(false);
+            return request.GetResponseAsync(receiver, registry, udpSocket, cancellationToken);
         }
 
         /// <summary>
@@ -587,7 +587,7 @@ namespace Lextm.SharpSnmpLib.Messaging
 
             // Whatever you change, try to keep the Send and the Receive close to each other.
             var buffer = new ArraySegment<byte>(bytes);
-            await udpSocket.SendToAsync(buffer, SocketFlags.None, receiver ?? throw new ArgumentNullException(nameof(receiver)), cancellationToken);
+            await udpSocket.SendToAsync(buffer, SocketFlags.None, receiver ?? throw new ArgumentNullException(nameof(receiver)), cancellationToken).ConfigureAwait(false);
 
             int count;
             byte[] reply = new byte[bufSize];
@@ -598,7 +598,7 @@ namespace Lextm.SharpSnmpLib.Messaging
 
             try
             {
-                var result = await udpSocket.ReceiveMessageFromAsync(new ArraySegment<byte>(reply), SocketFlags.None, remote, cancellationToken);
+                var result = await udpSocket.ReceiveMessageFromAsync(new ArraySegment<byte>(reply), SocketFlags.None, remote, cancellationToken).ConfigureAwait(false);
                 count = result.ReceivedBytes;
             }
             catch (SocketException ex)

--- a/SharpSnmpLib/Messaging/SnmpMessageExtension.cs
+++ b/SharpSnmpLib/Messaging/SnmpMessageExtension.cs
@@ -421,8 +421,10 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="message">The <see cref="ISnmpMessage"/>.</param>
         /// <param name="manager">Manager</param>
         /// <param name="socket">The socket.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
-        public static Task SendAsync(this ISnmpMessage message, EndPoint manager, Socket socket, CancellationToken cancellationToken = default)
+        public static Task SendAsync(this ISnmpMessage message, EndPoint manager, Socket socket)
+            => SendAsync(message, manager, socket, CancellationToken.None);
+
+        private static Task SendAsync(this ISnmpMessage message, EndPoint manager, Socket socket, CancellationToken cancellationToken)
         {
             if (message == null)
             {
@@ -522,9 +524,11 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="request">The <see cref="ISnmpMessage"/>.</param>
         /// <param name="receiver">Agent.</param>
         /// <param name="udpSocket">The UDP <see cref="Socket"/> to use to send/receive.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns></returns>
-        public static Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, Socket udpSocket, CancellationToken cancellationToken = default)
+        public static Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, Socket udpSocket)
+            => GetResponseAsync(request, receiver, udpSocket, CancellationToken.None);
+
+        private static Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, Socket udpSocket, CancellationToken cancellationToken)
         {
             if (request == null)
             {
@@ -557,9 +561,11 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="receiver">Agent.</param>
         /// <param name="udpSocket">The UDP <see cref="Socket"/> to use to send/receive.</param>
         /// <param name="registry">The user registry.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns></returns>
-        public static async Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, UserRegistry registry, Socket udpSocket, CancellationToken cancellationToken = default)
+        public static Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, UserRegistry registry, Socket udpSocket)
+            => GetResponseAsync(request, receiver, registry, udpSocket, CancellationToken.None);
+
+        public static async Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, UserRegistry registry, Socket udpSocket, CancellationToken cancellationToken)
         {
             if (request == null)
             {

--- a/SharpSnmpLib/Messaging/SnmpMessageExtension.cs
+++ b/SharpSnmpLib/Messaging/SnmpMessageExtension.cs
@@ -387,7 +387,8 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// </summary>
         /// <param name="message">The <see cref="ISnmpMessage"/>.</param>
         /// <param name="manager">Manager</param>
-        public static async Task SendAsync(this ISnmpMessage message, EndPoint manager)
+        /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
+        public static async Task SendAsync(this ISnmpMessage message, EndPoint manager, CancellationToken cancellationToken = default)
         {
             if (message == null)
             {
@@ -410,7 +411,7 @@ namespace Lextm.SharpSnmpLib.Messaging
 
             using (var socket = manager.GetSocket())
             {
-                await message.SendAsync(manager, socket).ConfigureAwait(false);
+                await message.SendAsync(manager, socket, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -420,7 +421,8 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="message">The <see cref="ISnmpMessage"/>.</param>
         /// <param name="manager">Manager</param>
         /// <param name="socket">The socket.</param>
-        public static async Task SendAsync(this ISnmpMessage message, EndPoint manager, Socket socket)
+        /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
+        public static async Task SendAsync(this ISnmpMessage message, EndPoint manager, Socket socket, CancellationToken cancellationToken = default)
         {
             if (message == null)
             {
@@ -447,7 +449,7 @@ namespace Lextm.SharpSnmpLib.Messaging
             }
 
             var buffer = new ArraySegment<byte>(message.ToBytes());
-            await socket.SendToAsync(buffer, SocketFlags.None, manager);
+            await socket.SendToAsync(buffer, SocketFlags.None, manager, cancellationToken);
         }
 
         /// <summary>
@@ -456,8 +458,9 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="request">The <see cref="ISnmpMessage"/>.</param>
         /// <param name="receiver">Port number.</param>
         /// <param name="registry">User registry.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns></returns>
-        public static async Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, UserRegistry registry)
+        public static async Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, UserRegistry registry, CancellationToken cancellationToken = default)
         {
             // TODO: make more usage of UserRegistry.
             if (request == null)
@@ -478,7 +481,7 @@ namespace Lextm.SharpSnmpLib.Messaging
 
             using (var socket = receiver.GetSocket())
             {
-                return await request.GetResponseAsync(receiver, registry, socket).ConfigureAwait(false);
+                return await request.GetResponseAsync(receiver, registry, socket, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -487,8 +490,9 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// </summary>
         /// <param name="request">The <see cref="ISnmpMessage"/>.</param>
         /// <param name="receiver">Port number.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns></returns>
-        public static async Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver)
+        public static async Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, CancellationToken cancellationToken = default)
         {
             if (request == null)
             {
@@ -508,7 +512,7 @@ namespace Lextm.SharpSnmpLib.Messaging
 
             using (var socket = receiver.GetSocket())
             {
-                return await request.GetResponseAsync(receiver, socket).ConfigureAwait(false);
+                return await request.GetResponseAsync(receiver, socket, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -518,8 +522,9 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="request">The <see cref="ISnmpMessage"/>.</param>
         /// <param name="receiver">Agent.</param>
         /// <param name="udpSocket">The UDP <see cref="Socket"/> to use to send/receive.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns></returns>
-        public static async Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, Socket udpSocket)
+        public static async Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, Socket udpSocket, CancellationToken cancellationToken = default)
         {
             if (request == null)
             {
@@ -542,7 +547,7 @@ namespace Lextm.SharpSnmpLib.Messaging
                 registry.Add(request.Parameters.UserName, request.Privacy);
             }
 
-            return await request.GetResponseAsync(receiver, registry, udpSocket).ConfigureAwait(false);
+            return await request.GetResponseAsync(receiver, registry, udpSocket, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -552,8 +557,9 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="receiver">Agent.</param>
         /// <param name="udpSocket">The UDP <see cref="Socket"/> to use to send/receive.</param>
         /// <param name="registry">The user registry.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns></returns>
-        public static async Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, UserRegistry registry, Socket udpSocket)
+        public static async Task<ISnmpMessage> GetResponseAsync(this ISnmpMessage request, IPEndPoint receiver, UserRegistry registry, Socket udpSocket, CancellationToken cancellationToken = default)
         {
             if (request == null)
             {
@@ -581,7 +587,7 @@ namespace Lextm.SharpSnmpLib.Messaging
 
             // Whatever you change, try to keep the Send and the Receive close to each other.
             var buffer = new ArraySegment<byte>(bytes);
-            await udpSocket.SendToAsync(buffer, SocketFlags.None, receiver ?? throw new ArgumentNullException(nameof(receiver)));
+            await udpSocket.SendToAsync(buffer, SocketFlags.None, receiver ?? throw new ArgumentNullException(nameof(receiver)), cancellationToken);
 
             int count;
             byte[] reply = new byte[bufSize];
@@ -592,7 +598,7 @@ namespace Lextm.SharpSnmpLib.Messaging
 
             try
             {
-                var result = await udpSocket.ReceiveMessageFromAsync(new ArraySegment<byte>(reply), SocketFlags.None, remote);
+                var result = await udpSocket.ReceiveMessageFromAsync(new ArraySegment<byte>(reply), SocketFlags.None, remote, cancellationToken);
                 count = result.ReceivedBytes;
             }
             catch (SocketException ex)

--- a/SharpSnmpLib/Messaging/SocketExtension.cs
+++ b/SharpSnmpLib/Messaging/SocketExtension.cs
@@ -34,7 +34,10 @@ namespace Lextm.SharpSnmpLib.Messaging
         {
             var cancellation = Task.Delay(Timeout.Infinite, cancellationToken);
             var send = socket.SendToAsync(buffer, socketFlags, remoteEP);
-            await Task.WhenAny(send, cancellation).ConfigureAwait(false);
+            var result = await Task.WhenAny(send, cancellation).ConfigureAwait(false);
+            //if this is the cancellation Task, it will throw so the next await will not be executed and thus not block
+            await result.ConfigureAwait(false);
+            //if not cancelled, await the original Task to get the result
             return await send.ConfigureAwait(false);
         }
 
@@ -42,7 +45,10 @@ namespace Lextm.SharpSnmpLib.Messaging
         {
             var cancellation = Task.Delay(Timeout.Infinite, cancellationToken);
             var receive = socket.ReceiveMessageFromAsync(buffer, socketFlags, remoteEndPoint);
-            await Task.WhenAny(receive, cancellation).ConfigureAwait(false);
+            var result = await Task.WhenAny(receive, cancellation).ConfigureAwait(false);
+            //if this is the cancellation Task, it will throw so the next await will not be executed and thus not block
+            await result.ConfigureAwait(false);
+            //if not cancelled, await the original Task to get the result
             return await receive.ConfigureAwait(false);
         }
     }

--- a/SharpSnmpLib/Messaging/SocketExtension.cs
+++ b/SharpSnmpLib/Messaging/SocketExtension.cs
@@ -28,9 +28,9 @@ namespace Lextm.SharpSnmpLib.Messaging
     /// <summary>
     /// Extension methods for <see cref="Socket"/>.
     /// </summary>
-    public static class SocketExtension
+    internal static class SocketExtension
     {
-        public static async Task<int> SendToAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEP, CancellationToken cancellationToken)
+        internal static async Task<int> SendToAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEP, CancellationToken cancellationToken)
         {
             var cancellation = Task.Delay(Timeout.Infinite, cancellationToken);
             var send = socket.SendToAsync(buffer, socketFlags, remoteEP);
@@ -41,7 +41,7 @@ namespace Lextm.SharpSnmpLib.Messaging
             return await send.ConfigureAwait(false);
         }
 
-        public static async Task<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint, CancellationToken cancellationToken)
+        internal static async Task<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint, CancellationToken cancellationToken)
         {
             var cancellation = Task.Delay(Timeout.Infinite, cancellationToken);
             var receive = socket.ReceiveMessageFromAsync(buffer, socketFlags, remoteEndPoint);

--- a/SharpSnmpLib/Messaging/SocketExtension.cs
+++ b/SharpSnmpLib/Messaging/SocketExtension.cs
@@ -1,0 +1,49 @@
+﻿// Socket extension class.
+// Copyright (C) 2021 Bianco Veigel, and other contributors.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lextm.SharpSnmpLib.Messaging
+{
+    /// <summary>
+    /// Extension methods for <see cref="Socket"/>.
+    /// </summary>
+    public static class SocketExtension
+    {
+        public static async Task<int> SendToAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEP, CancellationToken cancellationToken)
+        {
+            var cancellation = Task.Delay(Timeout.Infinite, cancellationToken);
+            var send = socket.SendToAsync(buffer, socketFlags, remoteEP);
+            await Task.WhenAny(send, cancellation).ConfigureAwait(false);
+            return await send.ConfigureAwait(false);
+        }
+
+        public static async Task<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint, CancellationToken cancellationToken)
+        {
+            var cancellation = Task.Delay(Timeout.Infinite, cancellationToken);
+            var receive = socket.ReceiveMessageFromAsync(buffer, socketFlags, remoteEndPoint);
+            await Task.WhenAny(receive, cancellation).ConfigureAwait(false);
+            return await receive.ConfigureAwait(false);
+        }
+    }
+}

--- a/Tests/CSharpCore/Unit/SocketTestFixture.cs
+++ b/Tests/CSharpCore/Unit/SocketTestFixture.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Lextm.SharpSnmpLib.Messaging;
+using Xunit;
+
+#pragma warning disable 1591
+namespace Lextm.SharpSnmpLib.Unit
+{
+    public class SocketTestFixture
+    {
+        [Fact]
+        public async Task TestGetAsyncCanBeCancelled()
+        {
+            var receiver = new IPEndPoint(IPAddress.Loopback, 11337);
+            using (new UdpClient(receiver))//listen to prevent ICMP unreachable
+            {
+                using (var cts = new CancellationTokenSource())
+                {
+                    var getTask = Messenger.GetAsync(VersionCode.V2, receiver, OctetString.Empty, new List<Variable>(), cts.Token);
+                    cts.Cancel();
+                    await Assert.ThrowsAsync<TaskCanceledException>(() => getTask);
+                }
+            }
+        }
+    }
+}
+#pragma warning restore 1591


### PR DESCRIPTION
I've added an optional CancellationToken parameter to all async methods. Cancellation is handled in `SocketExtension.SendToAsync` and `SocketExtension.ReceiveMessageFromAsync`. 

I've also added some missing `ConfigureAwait(false)` and removed some unneeded `async/await`

fixes #140 