### PR TITLE
fix xml serialization error for snmp type class

### DIFF
--- a/SharpSnmpLib/SnmpType.cs
+++ b/SharpSnmpLib/SnmpType.cs
@@ -35,7 +35,6 @@ namespace Lextm.SharpSnmpLib
     /// <summary>
     /// SNMP type code. The values are tag values for SNMP types.
     /// </summary>
-    [DataContract]
     public enum SnmpType // RFC1213 subset of ASN.1
     { 
         /// <summary>


### PR DESCRIPTION
SNMP Type class can not serialize any of its enum values when performing xml serialization. removing data contract tag allows it to serialize to xml. 