### PR TITLE
Integer32.ToErrorCode() throws an exception

### DIFF
--- a/SharpSnmpLib/Integer32.cs
+++ b/SharpSnmpLib/Integer32.cs
@@ -132,11 +132,6 @@ namespace Lextm.SharpSnmpLib
         /// <returns></returns>
         public ErrorCode ToErrorCode()
         {
-            if (_int > 19 || _int < 0)
-            {
-                throw new InvalidCastException();
-            }
-
             return (ErrorCode)_int;
         }
 


### PR DESCRIPTION
ToErrorCode() should not throw exceptions as the method is invoked by error message display and ToString() methods. Also, as the ErrorCode field of a SNMP packet is read/parsed by this class, a device migth brake/create a DOS by simply sending an error code unknown to the lib. We'd loose compatibility and introduce issues without any need or gain.