### PR TITLE
Fix v3 context name

### DIFF
--- a/SharpSnmpLib/Messaging/Discoverer.cs
+++ b/SharpSnmpLib/Messaging/Discoverer.cs
@@ -57,8 +57,9 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="broadcastAddress">The broadcast address.</param>
         /// <param name="community">The community.</param>
         /// <param name="interval">The discovering time interval, in milliseconds.</param>
+        /// <param name="contextName">The optional Context Name.</param>
         /// <remarks><paramref name="broadcastAddress"/> must be configured to a valid multicast address when IPv6 is used. For example, "[ff02::1]:161"</remarks>
-        public void Discover(VersionCode version, IPEndPoint broadcastAddress, OctetString community, int interval)
+        public void Discover(VersionCode version, IPEndPoint broadcastAddress, OctetString community, int interval, OctetString? contextName = null)
         {
             if (broadcastAddress == null)
             {
@@ -75,7 +76,7 @@ namespace Lextm.SharpSnmpLib.Messaging
             _requestId = Messenger.NextRequestId;
             if (version == VersionCode.V3)
             {
-                var discovery = new Discovery(Messenger.NextMessageId, _requestId, Messenger.MaxMessageSize);
+                var discovery = new Discovery(Messenger.NextMessageId, _requestId, Messenger.MaxMessageSize, contextName);
                 bytes = discovery.ToBytes();
             }
             else
@@ -282,8 +283,9 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="broadcastAddress">The broadcast address.</param>
         /// <param name="community">The community.</param>
         /// <param name="interval">The discovering time interval, in milliseconds.</param>
+        /// <param name="contextName">The optional context name.</param>
         /// <remarks><paramref name="broadcastAddress"/> must be an IPv4 address. IPv6 is not yet supported here.</remarks>
-        public async Task DiscoverAsync(VersionCode version, IPEndPoint broadcastAddress, OctetString community, int interval)
+        public async Task DiscoverAsync(VersionCode version, IPEndPoint broadcastAddress, OctetString community, int interval, OctetString? contextName = null)
         {
             if (broadcastAddress == null)
             {
@@ -300,7 +302,7 @@ namespace Lextm.SharpSnmpLib.Messaging
             _requestId = Messenger.NextRequestId;
             if (version == VersionCode.V3)
             {
-                var discovery = new Discovery(Messenger.NextMessageId, _requestId, Messenger.MaxMessageSize);
+                var discovery = new Discovery(Messenger.NextMessageId, _requestId, Messenger.MaxMessageSize, contextName);
                 bytes = discovery.ToBytes();
             }
             else

--- a/SharpSnmpLib/Messaging/Discovery.cs
+++ b/SharpSnmpLib/Messaging/Discovery.cs
@@ -57,8 +57,12 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="requestId">The request id.</param>
         /// <param name="messageId">The message id.</param>
         /// <param name="maxMessageSize">The max size of message.</param>
-        public Discovery(int messageId, int requestId, int maxMessageSize)
+        /// <param name="contextName">The optional Context Name.</param>
+        public Discovery(int messageId, int requestId, int maxMessageSize, OctetString? contextName = null)
         {
+            if (contextName == null)
+                contextName = OctetString.Empty;
+
             _discovery = new GetRequestMessage(
                 VersionCode.V3,
                 new Header(
@@ -68,7 +72,7 @@ namespace Lextm.SharpSnmpLib.Messaging
                 DefaultSecurityParameters,
                 new Scope(
                     OctetString.Empty,
-                    OctetString.Empty,
+                    contextName,
                     new GetRequestPdu(requestId, new List<Variable>())),
                 DefaultPrivacyProvider.DefaultPair,
                 null);
@@ -81,8 +85,12 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="messageId">The message id.</param>
         /// <param name="maxMessageSize">The max size of message.</param>
         /// <param name="type">Message type.</param>
-        public Discovery(int messageId, int requestId, int maxMessageSize, SnmpType type)
+        /// <param name="contextName">The optional Context Name.</param>
+        public Discovery(int messageId, int requestId, int maxMessageSize, SnmpType type, OctetString? contextName = null)
         {
+            if (contextName == null)
+                contextName = OctetString.Empty;
+
             switch (type)
             {
                 case SnmpType.GetRequestPdu:
@@ -96,7 +104,7 @@ namespace Lextm.SharpSnmpLib.Messaging
                             DefaultSecurityParameters,
                             new Scope(
                             OctetString.Empty,
-                            OctetString.Empty,
+                            contextName,
                             new GetRequestPdu(requestId, new List<Variable>())),
                             DefaultPrivacyProvider.DefaultPair,
                             null);
@@ -114,7 +122,7 @@ namespace Lextm.SharpSnmpLib.Messaging
                             DefaultSecurityParameters,
                             new Scope(
                             OctetString.Empty,
-                            OctetString.Empty,
+                            contextName,
                             new GetNextRequestPdu(requestId, new List<Variable>())),
                             DefaultPrivacyProvider.DefaultPair,
                             null);
@@ -132,7 +140,7 @@ namespace Lextm.SharpSnmpLib.Messaging
                             DefaultSecurityParameters,
                             new Scope(
                             OctetString.Empty,
-                            OctetString.Empty,
+                            contextName,
                             new GetBulkRequestPdu(requestId, 0, 0, new List<Variable>())),
                             DefaultPrivacyProvider.DefaultPair,
                             null);
@@ -150,7 +158,7 @@ namespace Lextm.SharpSnmpLib.Messaging
                             DefaultSecurityParameters,
                             new Scope(
                             OctetString.Empty,
-                            OctetString.Empty,
+                            contextName,
                             new SetRequestPdu(requestId, new List<Variable>())),
                             DefaultPrivacyProvider.DefaultPair,
                             null);
@@ -168,7 +176,7 @@ namespace Lextm.SharpSnmpLib.Messaging
                             DefaultSecurityParameters,
                             new Scope(
                             OctetString.Empty,
-                            OctetString.Empty,
+                            contextName,
                             new InformRequestPdu(requestId)),
                             DefaultPrivacyProvider.DefaultPair,
                             null);

--- a/SharpSnmpLib/Messaging/Discovery.cs
+++ b/SharpSnmpLib/Messaging/Discovery.cs
@@ -197,7 +197,17 @@ namespace Lextm.SharpSnmpLib.Messaging
             }
 
             using var socket = receiver.GetSocket();
-            return (ReportMessage)_discovery.GetResponse(timeout, receiver, Empty, socket);
+            var response = _discovery.GetResponse(timeout, receiver, Empty, socket);
+
+            try
+            {
+                return (ReportMessage)response;
+            }
+            catch
+            {
+                //The cast was not possible with a system that needed contextname=public
+                return new ReportMessage(response.Version, response.Header, response.Parameters, response.Scope, response.Privacy, response?.ToBytes());
+            }
         }
 
         /// <summary>

--- a/SharpSnmpLib/Messaging/Messenger.cs
+++ b/SharpSnmpLib/Messaging/Messenger.cs
@@ -1205,10 +1205,11 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// Returns a new discovery request.
         /// </summary>
         /// <param name="type">Message type.</param>
+        /// <param name="contextName">The optional context name.</param>
         /// <returns></returns>
-        public static Discovery GetNextDiscovery(SnmpType type)
+        public static Discovery GetNextDiscovery(SnmpType type, OctetString? contextName = null)
         {
-            return new Discovery(NextMessageId, NextRequestId, MaxMessageSize, type);
+            return new Discovery(NextMessageId, NextRequestId, MaxMessageSize, type, contextName);
         }
 
         /// <summary>

--- a/SharpSnmpLib/Messaging/Net6Discoverer.cs
+++ b/SharpSnmpLib/Messaging/Net6Discoverer.cs
@@ -38,8 +38,9 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="broadcastAddress">The broadcast address.</param>
         /// <param name="community">The community.</param>
         /// <param name="token">The cancellation token.</param>
+        /// <param name="contextName">The optional context name.</param>
         /// <remarks><paramref name="broadcastAddress"/> must be an IPv4 address. IPv6 is not yet supported here.</remarks>
-        public void Discover(VersionCode version, IPEndPoint broadcastAddress, OctetString? community, CancellationToken token)
+        public void Discover(VersionCode version, IPEndPoint broadcastAddress, OctetString? community, CancellationToken token, OctetString? contextName = null)
         {
             if (broadcastAddress == null)
             {
@@ -61,7 +62,7 @@ namespace Lextm.SharpSnmpLib.Messaging
             _requestId = Messenger.NextRequestId;
             if (version == VersionCode.V3)
             {
-                var discovery = new Discovery(Messenger.NextMessageId, _requestId, Messenger.MaxMessageSize);
+                var discovery = new Discovery(Messenger.NextMessageId, _requestId, Messenger.MaxMessageSize, contextName);
                 bytes = discovery.ToBytes();
             }
             else
@@ -141,7 +142,7 @@ namespace Lextm.SharpSnmpLib.Messaging
         /// <param name="community">The community.</param>
         /// <param name="token">The cancellation token.</param>
         /// <remarks><paramref name="broadcastAddress"/> must be an IPv4 address. IPv6 is not yet supported here.</remarks>
-        public async Task DiscoverAsync(VersionCode version, IPEndPoint broadcastAddress, OctetString community, CancellationToken token)
+        public async Task DiscoverAsync(VersionCode version, IPEndPoint broadcastAddress, OctetString community, CancellationToken token, OctetString? contextName = null)
         {
             if (broadcastAddress == null)
             {
@@ -158,7 +159,7 @@ namespace Lextm.SharpSnmpLib.Messaging
             _requestId = Messenger.NextRequestId;
             if (version == VersionCode.V3)
             {
-                var discovery = new Discovery(Messenger.NextMessageId, _requestId, Messenger.MaxMessageSize);
+                var discovery = new Discovery(Messenger.NextMessageId, _requestId, Messenger.MaxMessageSize, contextName);
                 bytes = discovery.ToBytes();
             }
             else


### PR DESCRIPTION
In V3, to connect to some devices, we need to initialize the scope contextName from the discovery